### PR TITLE
fixing issue #268

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
         exclude group: 'org.hibernate', module: 'hibernate-envers'
         exclude group: 'org.liquibase', module: 'liquibase-core'
     }
-    api("org.grails:grails-shell") {
+    compileOnlyApi("org.grails:grails-shell") {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
     }
     compileOnly "org.hibernate:hibernate-core:5.6.5.Final"


### PR DESCRIPTION
Tried fixing the following issue:
https://github.com/grails/grails-database-migration/issues/268

The problem seems to have appeared because of a migration to a newer Gradle version. Previously the `grails-shell` dependency was referenced with the `provided` scope, which was removed from Gradle. But the currently used `api` is not a proper replacement for `provided` as the dependency will be included in the Grails application artifact and not only during compile time.